### PR TITLE
Support launch transitions

### DIFF
--- a/cmd/lifecycled/main.go
+++ b/cmd/lifecycled/main.go
@@ -150,11 +150,8 @@ func main() {
 			SpotListenerInterval: 5 * time.Second,
 		}, sess, logger)
 
-		notice, err := daemon.Start(ctx)
-		if err != nil {
-			return err
-		}
-		if notice != nil {
+		notices := daemon.Start(ctx)
+		for notice := range notices {
 			log := logger.WithFields(logrus.Fields{"instanceId": instanceID, "notice": notice.Type()})
 			log.Info("Executing handler")
 
@@ -171,9 +168,8 @@ func main() {
 				log.WithError(err).Error("Failed to execute handler")
 			}
 			log.Info("Handler finished succesfully")
-
 		}
-		return nil
+		return daemon.Stop()
 	})
 
 	kingpin.MustParse(app.Parse(os.Args[1:]))

--- a/daemon_test.go
+++ b/daemon_test.go
@@ -153,7 +153,7 @@ func TestDaemon(t *testing.T) {
 
 			// Create and start the daemon
 			logger, hook := logrus.NewNullLogger()
-			ctx, cancel := context.WithTimeout(context.TODO(), 3*time.Second)
+			ctx, cancel := context.WithTimeout(context.TODO(), 1*time.Second)
 			defer cancel()
 
 			config := &lifecycled.Config{
@@ -164,7 +164,15 @@ func TestDaemon(t *testing.T) {
 			}
 
 			daemon := lifecycled.NewDaemon(config, sq, sn, as, metadata, logger)
-			notice, err := daemon.Start(ctx)
+			notices := daemon.Start(ctx)
+
+			var notice lifecycled.Notice
+			select {
+			case notice = <-notices:
+			case <-ctx.Done():
+			}
+
+			err := daemon.Stop()
 
 			if err != nil {
 				if !tc.expectDaemonError {
@@ -198,5 +206,4 @@ func TestDaemon(t *testing.T) {
 			}
 		})
 	}
-
 }

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d // indirect
 	golang.org/x/crypto v0.0.0-20181030102418-4d3f4d9ffa16 // indirect
 	golang.org/x/net v0.0.0-20181102091132-c10e9556a7bc // indirect
+	golang.org/x/sync v0.0.0-20190423024810-112230192c58
 	golang.org/x/sys v0.0.0-20181031143558-9b800f95dbbc // indirect
 	golang.org/x/text v0.3.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -37,6 +37,8 @@ golang.org/x/crypto v0.0.0-20181030102418-4d3f4d9ffa16 h1:y6ce7gCWtnH+m3dCjzQ1PC
 golang.org/x/crypto v0.0.0-20181030102418-4d3f4d9ffa16/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/net v0.0.0-20181102091132-c10e9556a7bc h1:ZMCWScCvS2fUVFw8LOpxyUUW5qiviqr4Dg5NdjLeiLU=
 golang.org/x/net v0.0.0-20181102091132-c10e9556a7bc/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
+golang.org/x/sync v0.0.0-20190423024810-112230192c58 h1:8gQV6CLnAEikrhgkHFbMAEhagSSnXWGV915qUMm9mrU=
+golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33 h1:I6FyU15t786LL7oL/hn43zqTuEGr4PN7F4XJ1p4E3Y8=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20181031143558-9b800f95dbbc h1:SdCq5U4J+PpbSDIl9bM0V1e1Ug1jsnBkAFvTs1htn7U=

--- a/spot.go
+++ b/spot.go
@@ -35,7 +35,7 @@ func (l *SpotListener) Type() string {
 }
 
 // Start the spot termination notice listener.
-func (l *SpotListener) Start(ctx context.Context, notices chan<- TerminationNotice, log *logrus.Entry) error {
+func (l *SpotListener) Start(ctx context.Context, notices chan<- Notice, log *logrus.Entry) error {
 	if !l.metadata.Available() {
 		return errors.New("ec2 metadata is not available")
 	}
@@ -89,6 +89,10 @@ type spotTerminationNotice struct {
 
 func (n *spotTerminationNotice) Type() string {
 	return n.noticeType
+}
+
+func (n *spotTerminationNotice) Transition() Transition {
+	return TerminationTransition
 }
 
 func (n *spotTerminationNotice) Handle(ctx context.Context, handler Handler, log *logrus.Entry) error {

--- a/tools/lifecycled-queue-cleaner/main.go
+++ b/tools/lifecycled-queue-cleaner/main.go
@@ -4,17 +4,17 @@ import (
 	"flag"
 	"log"
 	"regexp"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
-	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ec2"
-	"github.com/aws/aws-sdk-go/service/sqs"
 	"github.com/aws/aws-sdk-go/service/sns"
+	"github.com/aws/aws-sdk-go/service/sqs"
 )
 
 func main() {
@@ -213,7 +213,7 @@ func topicExists(sess *session.Session, snsTopic string) (bool, error) {
 
 func listInactiveSubscriptions(sess *session.Session) ([]string, error) {
 	var subs []string
-	var topics = make(map[string]bool,0)
+	var topics = make(map[string]bool, 0)
 	var count int
 
 	err := sns.New(sess).ListSubscriptionsPages(&sns.ListSubscriptionsInput{},
@@ -265,4 +265,3 @@ func deleteInactiveSubscriptions(sess *session.Session) (int, error) {
 	}
 	return deleted, nil
 }
-


### PR DESCRIPTION
We needed to be able to delay when our instances are reported as `InService` to more safely automate rolling our set of workers. This PR adds support for `autoscaling:EC2_INSTANCE_LAUNCHING` transitions to the `AutoscalingListener` and also allows the `Daemon` to receive a stream of notices (since we'll need to keep running after responding to a launch transition), returning only a channel when calling `Start` and safely canceling and cleaning up when calling `Stop`.